### PR TITLE
Using Set<Integer>[] to represent alignments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ dependencies {
   compile group: 'com.google.guava', name: 'guava', version: '19.0'
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.7'
   compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
+  compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
   compile group: 'com.lmax', name: 'disruptor', version: '3.3.6'
   
   // Test dependencies

--- a/src/edu/stanford/nlp/mt/decoder/feat/deplm/AbstractDependencyLanguageModelFeaturizer.java
+++ b/src/edu/stanford/nlp/mt/decoder/feat/deplm/AbstractDependencyLanguageModelFeaturizer.java
@@ -106,7 +106,7 @@ public abstract class AbstractDependencyLanguageModelFeaturizer extends Derivati
     PhraseAlignment alignment =  f.rule.abstractRule.alignment;
 
     for (int i = 0; i < tgtLength; ++i) {
-      int[] alignments = alignment.t2s(i);
+      Set<Integer> alignments = alignment.t2s(i);
       if (alignments != null) {
         for (int j : alignments) {
           s2t.get(j).add(i);
@@ -279,10 +279,10 @@ public abstract class AbstractDependencyLanguageModelFeaturizer extends Derivati
       IString tgtToken = f.targetPhrase.get(i);
       if (tgtToken.length() == 0 || TokenUtils.isPunctuation(tgtToken.toString()))
         continue;
-      if (alignment.t2s(i) == null || alignment.t2s(i).length < 1) {
+      if (alignment.t2s(i) == null || alignment.t2s(i).size() < 1) {
         // Unaligned -- try to attach to the next translated word in the rule
         // Check if there is a next word in the phrase and whether it is aligned
-        if ((i + 1) < targetLength && alignment.t2s(i+1) != null && alignment.t2s(i+1).length > 0) {
+        if ((i + 1) < targetLength && alignment.t2s(i+1) != null && alignment.t2s(i+1).size() > 0) {
           DepLMSubState subState = state.getSubState(i+1);
           if (subState == null)
             subState = state.addSubState(i+1);
@@ -299,8 +299,8 @@ public abstract class AbstractDependencyLanguageModelFeaturizer extends Derivati
       
       Integer sourceHeadIndex = null;
       int sourceDepIndex = -1;
-      for (int j = 0; j < alignment.t2s(i).length; j++) {
-        int srcIndex = alignment.t2s(i)[j] + f.sourcePosition;
+      for (int j = 0; j < alignment.t2s(i).size(); j++) {
+        int srcIndex = (int)alignment.t2s(i).toArray()[j] + f.sourcePosition;
         // Heuristic: choose the leftmost aligned token in the case of multiple alignments
         // TODO: Is this the best/right heuristic?
         if (sourceHeadIndex == null && this.dependent2Head.get(srcIndex) != null) {

--- a/src/edu/stanford/nlp/mt/decoder/feat/sparse/DiscriminativeAlignments.java
+++ b/src/edu/stanford/nlp/mt/decoder/feat/sparse/DiscriminativeAlignments.java
@@ -81,7 +81,7 @@ public class DiscriminativeAlignments implements RuleFeaturizer<IString,String> 
 
     // Target-side alignments
     for (int i = 0; i < tgtLength; ++i) {
-      int[] alignments = alignment.t2s(i);
+      Set<Integer> alignments = alignment.t2s(i);
       if (alignments == null) {
         if (addTargetInsertions) {
           IString tgtWord = f.targetPhrase.get(i);
@@ -90,7 +90,7 @@ public class DiscriminativeAlignments implements RuleFeaturizer<IString,String> 
         }
 
       } else {
-        if (alignments.length > 1) {
+        if (alignments.size() > 1) {
           hasMultipleAlignments.set(i);
         }
         for (int j : alignments) {
@@ -117,7 +117,7 @@ public class DiscriminativeAlignments implements RuleFeaturizer<IString,String> 
         for (int tgtIndex : alignments) {
           alignedTargetWords.add(targetRepresentation(f.targetPhrase.get(tgtIndex)));
           if (hasMultipleAlignments.get(tgtIndex)) {
-            int[] srcIndices = alignment.t2s(tgtIndex);
+            Set<Integer> srcIndices = alignment.t2s(tgtIndex);
             for (int sIndex : srcIndices) {
               IString srcToken = f.sourcePhrase.get(sIndex);
               alignedSourceWords.add(sourceRepresentation(srcToken));

--- a/src/edu/stanford/nlp/mt/decoder/feat/sparse/PrefixAlignmentFeaturizer.java
+++ b/src/edu/stanford/nlp/mt/decoder/feat/sparse/PrefixAlignmentFeaturizer.java
@@ -1,9 +1,6 @@
 package edu.stanford.nlp.mt.decoder.feat.sparse;
 
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import edu.stanford.nlp.mt.decoder.feat.DerivationFeaturizer;
 import edu.stanford.nlp.mt.decoder.feat.FeatureUtils;
@@ -116,7 +113,7 @@ implements RuleFeaturizer<IString,String>{
     int numTargetInsertions = 0;
     BitSet sourceAligned = new BitSet(f.sourcePhrase.size());
     for (int i = 0, sz = f.targetPhrase.size(); i < sz; ++i) {
-      int[] t2s = a.t2s(i);
+      Set<Integer> t2s = a.t2s(i);
       if (t2s == null) {
         ++numTargetInsertions;
       } else {

--- a/src/edu/stanford/nlp/mt/decoder/feat/sparse/RuleUnalignedFeaturizer.java
+++ b/src/edu/stanford/nlp/mt/decoder/feat/sparse/RuleUnalignedFeaturizer.java
@@ -1,9 +1,6 @@
 package edu.stanford.nlp.mt.decoder.feat.sparse;
 
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import edu.stanford.nlp.mt.decoder.feat.FeatureUtils;
 import edu.stanford.nlp.mt.decoder.feat.RuleFeaturizer;
@@ -47,8 +44,8 @@ public class RuleUnalignedFeaturizer implements RuleFeaturizer<IString, String> 
     int numTargetInsertions = 0;
     BitSet sourceAligned = new BitSet(f.sourcePhrase.size());
     for (int i = 0, sz = f.targetPhrase.size(); i < sz; ++i) {
-      int[] t2s = a.t2s(i);
-      if (t2s == null || t2s.length == 0) {
+      Set<Integer> t2s = a.t2s(i);
+      if (t2s == null || t2s.size() == 0) {
         ++numTargetInsertions;
       } else {
         for (int j : t2s) sourceAligned.set(j);

--- a/src/edu/stanford/nlp/mt/decoder/util/Derivation.java
+++ b/src/edu/stanford/nlp/mt/decoder/util/Derivation.java
@@ -1,6 +1,8 @@
 package edu.stanford.nlp.mt.decoder.util;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 
 import edu.stanford.nlp.mt.decoder.feat.FeatureExtractor;
@@ -251,7 +253,7 @@ State<Derivation<TK, FV>> {
       Scorer<FV> scorer, int sourceInputId) {
     // Manufacture a new rule
     Sequence<TK> ruleTarget = rule.abstractRule.target.concat(targetSpan);
-    int[][] e2f = new int[ruleTarget.size()][];
+    Set<Integer>[] e2f = new TreeSet[ruleTarget.size()];
     for (int i = 0; i < rule.abstractRule.target.size(); ++i) {
       e2f[i] = rule.abstractRule.alignment.t2s(i);
     }

--- a/src/edu/stanford/nlp/mt/decoder/util/SyntheticRules.java
+++ b/src/edu/stanford/nlp/mt/decoder/util/SyntheticRules.java
@@ -1,11 +1,6 @@
 package edu.stanford.nlp.mt.decoder.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -231,7 +226,8 @@ public final class SyntheticRules {
     final String[] featureNames = (String[]) inferer.phraseGenerator.getFeatureNames().toArray();
     int numRules = 0;
 
-    int[][] e2f = {{ 0 }};
+    Set<Integer>[] e2f = new TreeSet[1];
+    e2f[0] = new TreeSet(Collections.singletonList(new int[]{0}));
     PhraseAlignment alignment = new PhraseAlignment(e2f);
     
     for(int i = 0; i < sourceSequence.size(); ++i) {
@@ -380,9 +376,9 @@ public final class SyntheticRules {
 
           CoverageSet cov = new CoverageSet(sourceSequence.size());
           cov.set(r.fi, r.fj);
-          int[][] e2f = new int[tgt.size()][src.size()];
+          Set<Integer>[] e2f = new TreeSet[tgt.size()];
           for (int eIdx = r.ei; eIdx < r.ej; ++eIdx) {
-            e2f[eIdx - r.ei] = sym.e2f(eIdx).stream().mapToInt(a -> a - r.fi).toArray();
+            e2f[eIdx - r.ei] = new TreeSet(Collections.singletonList(sym.e2f(eIdx).stream().mapToInt(a -> a - r.fi).toArray()));
           }
           PhraseAlignment alignment = new PhraseAlignment(e2f);
 
@@ -464,9 +460,9 @@ public final class SyntheticRules {
           CoverageSet cov = new CoverageSet(sourceSequence.size());
           cov.set(fi, fj);   
 
-          int[][] e2f = new int[tgt.size()][src.size()];
+          Set<Integer>[] e2f = new TreeSet[tgt.size()];
           for (int k = 0; k < tgt.size() && k < src.size(); ++k) {
-            e2f[k] = new int[] { k } ;
+            e2f[k] = new TreeSet(Collections.singletonList(new int[]{k}));
           }
           PhraseAlignment alignment = new PhraseAlignment(e2f);
 

--- a/src/edu/stanford/nlp/mt/decoder/util/SyntheticRules.java
+++ b/src/edu/stanford/nlp/mt/decoder/util/SyntheticRules.java
@@ -378,8 +378,9 @@ public final class SyntheticRules {
           cov.set(r.fi, r.fj);
           Set<Integer>[] e2f = new TreeSet[tgt.size()];
           for (int eIdx = r.ei; eIdx < r.ej; ++eIdx) {
-            e2f[eIdx - r.ei] = new TreeSet(Collections.singletonList(sym.e2f(eIdx).stream().mapToInt(a -> a - r.fi).toArray()));
+            e2f[eIdx - r.ei] = sym.e2f(eIdx).stream().mapToInt(a -> a - r.fi).boxed().collect(Collectors.toCollection(() -> new TreeSet()));
           }
+
           PhraseAlignment alignment = new PhraseAlignment(e2f);
 
           ConcreteRule<TK,FV> syntheticRule = null;

--- a/src/edu/stanford/nlp/mt/decoder/util/SyntheticRules.java
+++ b/src/edu/stanford/nlp/mt/decoder/util/SyntheticRules.java
@@ -1,6 +1,7 @@
 package edu.stanford.nlp.mt.decoder.util;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -226,8 +227,7 @@ public final class SyntheticRules {
     final String[] featureNames = (String[]) inferer.phraseGenerator.getFeatureNames().toArray();
     int numRules = 0;
 
-    Set<Integer>[] e2f = new TreeSet[1];
-    e2f[0] = new TreeSet(Collections.singletonList(new int[]{0}));
+    Set<Integer>[] e2f = new Set[] { Collections.singleton(0) };
     PhraseAlignment alignment = new PhraseAlignment(e2f);
     
     for(int i = 0; i < sourceSequence.size(); ++i) {
@@ -462,7 +462,7 @@ public final class SyntheticRules {
 
           Set<Integer>[] e2f = new TreeSet[tgt.size()];
           for (int k = 0; k < tgt.size() && k < src.size(); ++k) {
-            e2f[k] = new TreeSet(Collections.singletonList(new int[]{k}));
+            e2f[k] = Collections.singleton(k);
           }
           PhraseAlignment alignment = new PhraseAlignment(e2f);
 

--- a/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
+++ b/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
@@ -69,7 +69,7 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
   public static final int DEFAULT_MAX_PHRASE_LEN = 12;
   private static final int RULE_CACHE_THRESHOLD = 10000;
   private static final double MIN_LEX_PROB = 1e-5;
-  private static final int MAX_FERTILITY = 5;
+  private static final int MAX_FERTILITY = 300;
   
   /**
    * Parallelize TM queries. 
@@ -723,6 +723,7 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
       // Generate rules for this span
       final Sequence<IString> sourceSpan = source.subsequence(i, j);
       final CoverageSet sourceCoverage = new CoverageSet(source.size());
+      System.out.println(sourceCoverage);
       sourceCoverage.set(i, j);
       List<Rule<IString>> rules = ruleCache == null ? null : ruleCache.get(sourceSpan);
       if (rules == null) {
@@ -1099,10 +1100,10 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
     private final int hashCode;
     public AlignmentTemplate(SampledRule rule) {
       this.rule = rule;
-      int[] e2fPrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(rule.e2fAll());
-      int[] f2ePrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(rule.f2eAll());
-      this.hashCode = MurmurHash2.hash32(e2fPrimitive, rule.sourceLength(), 1) ^
-          MurmurHash2.hash32(f2ePrimitive, rule.targetLength(), 1);
+      String e2fString = String.join(",", org.apache.commons.lang3.ArrayUtils.toStringArray(rule.e2fAll()));
+      String f2eString = String.join(",", org.apache.commons.lang3.ArrayUtils.toStringArray(rule.f2eAll()));
+      this.hashCode = MurmurHash2.hash32(e2fString, rule.sourceLength(), 1) ^
+          MurmurHash2.hash32(f2eString, rule.targetLength(), 1);
     }
     @Override
     public String toString() { return rule.toString(); }

--- a/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
+++ b/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
@@ -3,12 +3,7 @@ package edu.stanford.nlp.mt.tm;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -402,7 +397,7 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
           // See {@link edu.stanford.nlp.mt.train.MosesPharoahFeatureExtractor#FeaturizeSentence}
           // TODO(spenceg) Maybe we should discriminate? Will greatly increase the size of the
           // of the cooc table.
-          int[] tgtAlign = s.f2e(i);
+          Set<Integer> tgtAlign = s.f2e(i);
           for (int j : tgtAlign) {
             int tgtId = s.target(j);
             coocTable.addCooc(srcId, tgtId);
@@ -1104,8 +1099,10 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
     private final int hashCode;
     public AlignmentTemplate(SampledRule rule) {
       this.rule = rule;
-      this.hashCode = MurmurHash2.hash32(rule.f2eAll(), rule.sourceLength(), 1) ^ 
-          MurmurHash2.hash32(rule.e2fAll(), rule.targetLength(), 1);
+      int[] e2fPrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(rule.e2fAll());
+      int[] f2ePrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(rule.f2eAll());
+      this.hashCode = MurmurHash2.hash32(e2fPrimitive, rule.sourceLength(), 1) ^
+          MurmurHash2.hash32(f2ePrimitive, rule.targetLength(), 1);
     }
     @Override
     public String toString() { return rule.toString(); }
@@ -1174,14 +1171,14 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
         feSum = c_f_e / (double) c_e;
         
       } else {
-        int[] tgtAlign = rule.sentencePair.f2e(i);
+        Set<Integer> tgtAlign = rule.sentencePair.f2e(i);
         for (int j : tgtAlign) {
           int tgtId = rule.sentencePair.target(j);
           int c_f_e = coocTable.getJointCount(srcId, tgtId);
           int c_e = coocTable.getTgtMarginal(tgtId);
           feSum += (c_f_e / (double) c_e);
         }
-        feSum /= (double) tgtAlign.length;
+        feSum /= (double) tgtAlign.size();
       }
       if (feSum == 0.0) feSum = MIN_LEX_PROB;
       lex_f_e *= feSum;
@@ -1199,14 +1196,14 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
         efSum = c_e_f / (double) c_f;
         
       } else {
-        int[] srcAlign = rule.sentencePair.e2f(i);
+        Set<Integer> srcAlign = rule.sentencePair.e2f(i);
         for (int j : srcAlign) {
           final int srcId = rule.sentencePair.source(j);
           int c_e_f = coocTable.getJointCount(srcId, tgtId);
           int c_f = coocTable.getSrcMarginal(srcId);
           efSum += (c_e_f / (double) c_f);
         }
-        efSum /= (double) srcAlign.length;
+        efSum /= (double) srcAlign.size();
         
       }
       if (efSum == 0.0) efSum = MIN_LEX_PROB;
@@ -1325,7 +1322,7 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
     for(int sourcePos = startSource; sourcePos < endSource; sourcePos++) {
       assert sourcePos < sentencePair.sourceLength() : String.format("[%d,%d) %d %d ", startSource, endSource, sourcePos, sentencePair.sourceLength());
       if ( ! sentencePair.isSourceUnaligned(sourcePos)) {
-        int[] targetPositions = sentencePair.f2e(sourcePos);
+        Set<Integer> targetPositions = sentencePair.f2e(sourcePos);
         for(int targetPos : targetPositions) {
           if (targetPos < minTarget) {
             minTarget = targetPos;
@@ -1342,7 +1339,7 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
     // Admissibility check
     for (int i = minTarget; i <= maxTarget; ++i) {
       if ( ! sentencePair.isTargetUnaligned(i)) {
-        int[] srcPositions = sentencePair.e2f(i);
+        Set<Integer> srcPositions = sentencePair.e2f(i);
         for (int sourcePos : srcPositions) {
           if (sourcePos < startSource || sourcePos >= endSource) {
             // Failed check

--- a/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
+++ b/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
@@ -723,7 +723,6 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
       // Generate rules for this span
       final Sequence<IString> sourceSpan = source.subsequence(i, j);
       final CoverageSet sourceCoverage = new CoverageSet(source.size());
-      System.out.println(sourceCoverage);
       sourceCoverage.set(i, j);
       List<Rule<IString>> rules = ruleCache == null ? null : ruleCache.get(sourceSpan);
       if (rules == null) {

--- a/src/edu/stanford/nlp/mt/tm/SampledRule.java
+++ b/src/edu/stanford/nlp/mt/tm/SampledRule.java
@@ -121,20 +121,19 @@ public class SampledRule {
    * 
    * @return
    */
-  public int[][] e2f() {
+  public Set<Integer>[] e2f() {
     int eDim = tgtEndExclusive - tgtStartInclusive;
-    int[][] e2f = new int[eDim][];
+    Set<Integer>[] e2f = new TreeSet[eDim];
     for (int i = tgtStartInclusive; i < tgtEndExclusive; ++i) {
       int localIdx = i - tgtStartInclusive;
       Set<Integer> e2fI = sentencePair.e2f(i);
       int srcAlignDim = e2fI.size();
-      e2f[localIdx] = new int[srcAlignDim];
-      if (srcAlignDim > 0) {
-        System.arraycopy(e2fI, 0, e2f[localIdx], 0, srcAlignDim);
-        for (int j = 0; j < srcAlignDim; ++j) {
-          e2f[localIdx][j] -= srcStartInclusive;
-        }
-      }
+      e2f[localIdx] = e2fI;
+//      if (srcAlignDim > 0) {
+//        for (int j = 0; j < srcAlignDim; ++j) {
+//          e2f[localIdx][j] -= srcStartInclusive;
+//        }
+//      }
     }
     return e2f;
   }

--- a/src/edu/stanford/nlp/mt/tm/SampledRule.java
+++ b/src/edu/stanford/nlp/mt/tm/SampledRule.java
@@ -6,7 +6,6 @@ import java.util.TreeSet;
 
 import edu.stanford.nlp.mt.util.MurmurHash2;
 import edu.stanford.nlp.mt.util.ParallelSuffixArray.SentencePair;
-import sun.reflect.generics.tree.Tree;
 
 /**
  * A rule sampled from the bitext.

--- a/src/edu/stanford/nlp/mt/tm/SampledRule.java
+++ b/src/edu/stanford/nlp/mt/tm/SampledRule.java
@@ -1,9 +1,12 @@
 package edu.stanford.nlp.mt.tm;
 
 import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
 
 import edu.stanford.nlp.mt.util.MurmurHash2;
 import edu.stanford.nlp.mt.util.ParallelSuffixArray.SentencePair;
+import sun.reflect.generics.tree.Tree;
 
 /**
  * A rule sampled from the bitext.
@@ -109,7 +112,7 @@ public class SampledRule {
    * 
    * @return
    */
-  public int[] e2fAll() {
+  public Set<Integer>[] e2fAll() {
     return sentencePair.e2f(tgtStartInclusive, tgtEndExclusive);
   }
   
@@ -123,8 +126,8 @@ public class SampledRule {
     int[][] e2f = new int[eDim][];
     for (int i = tgtStartInclusive; i < tgtEndExclusive; ++i) {
       int localIdx = i - tgtStartInclusive;
-      int[] e2fI = sentencePair.e2f(i);
-      int srcAlignDim = e2fI.length;
+      Set<Integer> e2fI = sentencePair.e2f(i);
+      int srcAlignDim = e2fI.size();
       e2f[localIdx] = new int[srcAlignDim];
       if (srcAlignDim > 0) {
         System.arraycopy(e2fI, 0, e2f[localIdx], 0, srcAlignDim);
@@ -141,7 +144,7 @@ public class SampledRule {
    * 
    * @return
    */
-  public int[] f2eAll() {
+  public Set<Integer>[] f2eAll() {
     return sentencePair.f2e(srcStartInclusive, srcEndExclusive);
   }
   
@@ -155,8 +158,8 @@ public class SampledRule {
     int[][] f2e = new int[fDim][];
     for (int i = srcStartInclusive; i < srcEndExclusive; ++i) {
       int localIdx = i - srcStartInclusive;
-      int[] f2eI = sentencePair.f2e(i);
-      int tgtAlignDim = f2eI.length;
+      Set<Integer> f2eI = sentencePair.f2e(i);
+      int tgtAlignDim = f2eI.size();
       f2e[localIdx] = new int[tgtAlignDim];
       if (tgtAlignDim > 0) {
         System.arraycopy(f2eI, 0, f2e[localIdx], 0, f2e[localIdx].length);
@@ -174,10 +177,10 @@ public class SampledRule {
    * @param i
    * @return
    */
-  public int[] f2e(int i) {
+  public Set<Integer> f2e(int i) {
     int srcIndex = srcStartInclusive + i;
     if (srcIndex < 0 || srcIndex >= srcEndExclusive) throw new ArrayIndexOutOfBoundsException();
-    return sentencePair.isSourceUnaligned(srcIndex) ? new int[0] : sentencePair.f2e(srcIndex);
+    return sentencePair.isSourceUnaligned(srcIndex) ? new TreeSet<>() : sentencePair.f2e(srcIndex);
   }
 
   /**
@@ -186,9 +189,9 @@ public class SampledRule {
    * @param i
    * @return
    */
-  public int[] e2f(int i) {
+  public Set<Integer> e2f(int i) {
     int tgtIndex = tgtStartInclusive + i;
     if (tgtIndex < 0 || tgtIndex >= tgtEndExclusive) throw new ArrayIndexOutOfBoundsException();
-    return sentencePair.isTargetUnaligned(tgtIndex) ? new int[0] : sentencePair.e2f(tgtIndex);
+    return sentencePair.isTargetUnaligned(tgtIndex) ? new TreeSet<>() : sentencePair.e2f(tgtIndex);
   }
 }

--- a/src/edu/stanford/nlp/mt/tm/WordBasedReorderingModel.java
+++ b/src/edu/stanford/nlp/mt/tm/WordBasedReorderingModel.java
@@ -34,6 +34,6 @@ public class WordBasedReorderingModel extends AbstractDynamicReorderingModel {
     if (fi == rule.sentencePair.sourceLength() || ei == rule.sentencePair.targetLength())
       return false;
 
-    return rule.sentencePair.isSourceUnaligned(fi) ? false : ArrayMath.indexOf(ei, rule.sentencePair.f2e(fi)) >= 0;
+    return rule.sentencePair.isSourceUnaligned(fi) ? false : rule.sentencePair.f2e(fi).contains(ei);
   }
 }

--- a/src/edu/stanford/nlp/mt/train/GIZAWordAlignment.java
+++ b/src/edu/stanford/nlp/mt/train/GIZAWordAlignment.java
@@ -219,7 +219,7 @@ public class GIZAWordAlignment extends AbstractWordAlignment {
    * @param f2e
    * @return
    */
-  public static String toGizaString(int[][] f2e) {
+  public static String toGizaString(Set<Integer>[] f2e) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < f2e.length; ++i) {
       for (int j : f2e[i]) {

--- a/src/edu/stanford/nlp/mt/util/AlignedSentence.java
+++ b/src/edu/stanford/nlp/mt/util/AlignedSentence.java
@@ -18,7 +18,7 @@ public class AlignedSentence implements Serializable {
   // 256-1, since 0 is used to indicate a null alignment in the compact
   // representation.
   public static final int MAX_SENTENCE_LENGTH = 256 - 1;
-  public static final int MAX_FERTILITY = 4;
+  public static final int MAX_FERTILITY = 300;
   
   public int[] source;
   public int[] target;

--- a/src/edu/stanford/nlp/mt/util/AlignedSentence.java
+++ b/src/edu/stanford/nlp/mt/util/AlignedSentence.java
@@ -23,8 +23,8 @@ public class AlignedSentence implements Serializable {
   public int[] source;
   public int[] target;
 
-  protected int[] f2e;
-  protected int[] e2f;
+  protected Set<Integer>[] f2e;
+  protected Set<Integer>[] e2f;
   
   /**
    * No-arg constructor for deserialization.
@@ -45,8 +45,8 @@ public class AlignedSentence implements Serializable {
     if (target.length > MAX_SENTENCE_LENGTH) throw new IllegalArgumentException();
     this.source = source;
     this.target = target;
-    this.f2e = flatten(f2e);
-    this.e2f = flatten(e2f);
+    this.f2e = f2e;
+    this.e2f = e2f;
   }
 
   /**
@@ -90,24 +90,24 @@ public class AlignedSentence implements Serializable {
     return links;
   }
   
-  public int[] f2e(int i) {
+  public Set<Integer> f2e(int i) {
     if (i < 0 || i >= source.length) throw new IndexOutOfBoundsException();
-    return expand(f2e[i]);
+    return f2e[i];
   }
   
-  public int[] e2f(int i) {
+  public Set<Integer> e2f(int i) {
     if (i < 0 || i >= target.length) throw new IndexOutOfBoundsException();
-    return expand(e2f[i]);
+    return e2f[i];
   }
   
   public boolean isSourceUnaligned(int i) {
     if (i < 0 || i >= source.length) throw new IndexOutOfBoundsException();
-    return f2e[i] == 0;
+    return f2e[i].size() == 0;
   }
   
   public boolean isTargetUnaligned(int i) {
     if (i < 0 || i >= target.length) throw new IndexOutOfBoundsException();
-    return e2f[i] == 0;
+    return e2f[i].size() == 0;
   }
     
   public int sourceLength() { return source.length; }

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -4,16 +4,13 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.lang.reflect.Array;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import edu.stanford.nlp.util.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,9 +36,9 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
   private static final Logger logger = LogManager.getLogger(ParallelSuffixArray.class);
   
   protected int[] srcBitext;
-  protected int[] f2e;
+  protected Set<Integer>[] f2e;
   protected int[] tgtBitext;
-  protected int[] e2f;
+  protected Set<Integer>[] e2f;
   protected int[] srcSuffixArray; 
   protected int[] tgtSuffixArray;
   
@@ -86,8 +83,10 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
   public void write(Kryo kryo, Output output) {
     writeArray(srcBitext, output);
     writeArray(tgtBitext, output);
-    writeArray(e2f, output);
-    writeArray(f2e, output);
+    int[] e2fPrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(e2f);
+    writeArray(e2fPrimitive, output);
+    int[] f2ePrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(f2e);
+    writeArray(f2ePrimitive, output);
     writeArray(srcSuffixArray, output);
     writeArray(tgtSuffixArray, output);
     output.writeInt(numSentences, true);
@@ -103,8 +102,18 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
   public void read(Kryo kryo, Input input) {
     srcBitext = readArray(input);
     tgtBitext = readArray(input);
-    e2f = readArray(input);
-    f2e = readArray(input);
+    Integer[] readArrayResult = org.apache.commons.lang3.ArrayUtils.toObject(readArray(input));
+    e2f = new TreeSet[readArrayResult.length];
+    for(int i =0; i<readArrayResult.length; i++){
+      e2f[i] = new TreeSet();
+      e2f[i].add(readArrayResult[i]);
+    }
+    readArrayResult = org.apache.commons.lang3.ArrayUtils.toObject(readArray(input));
+    f2e = new TreeSet[readArrayResult.length];
+    for(int i =0; i<readArrayResult.length; i++){
+      f2e[i] = new TreeSet();
+      f2e[i].add(readArrayResult[i]);
+    }
     srcSuffixArray = readArray(input);
     tgtSuffixArray = readArray(input);
     numSentences = input.readInt(true);
@@ -193,11 +202,11 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
     final int srcLength = numSourcePositions + numSentences;
     if (srcLength < 0) throw new RuntimeException("Maximum source bitext size exceeded");
     srcBitext = new int[srcLength];
-    f2e = new int[srcLength];
+    f2e = new TreeSet[srcLength];
     final int tgtLength = numTargetPositions + numSentences;
     if (tgtLength < 0) throw new RuntimeException("Maximum target bitext size exceeded");
     tgtBitext = new int[tgtLength];
-    e2f = new int[tgtLength];
+    e2f = new TreeSet[tgtLength];
     
     // Create the arrays and read the files again
     try (LineNumberReader fReader = IOTools.getReaderFromFile(source)) {
@@ -247,19 +256,21 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
     int numTargetPositions = corpus.numTargetPositions();
     int srcLength = numSourcePositions + numSentences;
     srcBitext = new int[srcLength];
-    f2e = new int[srcLength];
+    f2e = new TreeSet[srcLength];
     int tgtLength = numTargetPositions + numSentences;
     tgtBitext = new int[tgtLength];
-    e2f = new int[tgtLength];
+    e2f = new TreeSet[tgtLength];
     int srcOffset = 0;
     int tgtOffset = 0;
     for (AlignedSentence sentence : corpus) {
       System.arraycopy(sentence.source, 0, srcBitext, srcOffset, sentence.sourceLength());
-      System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
+//      System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
       System.arraycopy(sentence.target, 0, tgtBitext, tgtOffset, sentence.targetLength());
-      System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
+//      System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
       srcOffset += sentence.sourceLength();
       tgtOffset += sentence.targetLength();
+      f2e = sentence.f2e;
+      e2f = sentence.e2f;
       // Source points to target
       srcBitext[srcOffset] = toSentenceOffset(tgtOffset);
       // Target points to source
@@ -863,7 +874,7 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       return tgtBitext[bitextPos];
     }
     
-    public int[] f2e(int startInclusive, int endExclusive) {
+    public Set<Integer>[] f2e(int startInclusive, int endExclusive) {
       if (startInclusive >= endExclusive) throw new IllegalArgumentException();
       int bitextStartInclusive = srcStartInclusive + startInclusive;
       int bitextEndExclusive = srcStartInclusive + endExclusive;
@@ -871,13 +882,13 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       return Arrays.copyOfRange(f2e, bitextStartInclusive, bitextEndExclusive);
     }
     
-    public int[] f2e(int i) {
+    public Set<Integer> f2e(int i) {
       int bitextPos = srcStartInclusive + i;
       if (bitextPos < srcStartInclusive || bitextPos >= srcEndExclusive) throw new ArrayIndexOutOfBoundsException();
-      return AlignedSentence.expand(f2e[bitextPos]);
+      return f2e[bitextPos];
     }
     
-    public int[] e2f(int startInclusive, int endExclusive) {
+    public Set<Integer>[] e2f(int startInclusive, int endExclusive) {
       if (startInclusive >= endExclusive) throw new IllegalArgumentException();
       int bitextStartInclusive = tgtStartInclusive + startInclusive;
       int bitextEndExclusive = tgtStartInclusive + endExclusive;
@@ -885,22 +896,22 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       return Arrays.copyOfRange(e2f, bitextStartInclusive, bitextEndExclusive);
     }
     
-    public int[] e2f(int i) {
+    public Set<Integer> e2f(int i) {
       int bitextPos = tgtStartInclusive + i;
       if (bitextPos < tgtStartInclusive || bitextPos >= tgtEndExclusive) throw new ArrayIndexOutOfBoundsException();
-      return AlignedSentence.expand(e2f[bitextPos]);
+      return e2f[bitextPos];
     }
     
     public boolean isSourceUnaligned(int i) {
       int bitextPos = srcStartInclusive + i;
       if (bitextPos < srcStartInclusive || bitextPos >= srcEndExclusive) throw new ArrayIndexOutOfBoundsException();
-      return f2e[bitextPos] == 0;
+      return f2e[bitextPos].size() == 0;
     }
     
     public boolean isTargetUnaligned(int i) {
       int bitextPos = tgtStartInclusive + i;
       if (bitextPos < tgtStartInclusive || bitextPos >= tgtEndExclusive) throw new ArrayIndexOutOfBoundsException();
-      return e2f[bitextPos] == 0;
+      return e2f[bitextPos].size() == 0;
     }
     
     public ParallelSuffixArrayEntry getParallelEntry() {

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -98,7 +97,7 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
   private static void writeSets(Set<Integer>[] sets, Output output) {
     output.writeInt(sets.length, true);
     for (Set<Integer> set: sets){
-      int[] setPrimitive = (int[]) ArrayUtils.toPrimitive(set);
+      int[] setPrimitive = set.stream().mapToInt(a -> a).toArray();
       writeArray(setPrimitive, output);
     }
   }

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -83,10 +83,16 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
   public void write(Kryo kryo, Output output) {
     writeArray(srcBitext, output);
     writeArray(tgtBitext, output);
-    int[] e2fPrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(e2f);
-    writeArray(e2fPrimitive, output);
-    int[] f2ePrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(f2e);
-    writeArray(f2ePrimitive, output);
+    writeArray(new int[]{e2f.length}, output);
+    for (Set<Integer> e2fI: e2f){
+      int[] e2fPrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(e2fI);
+      writeArray(e2fPrimitive, output);
+    }
+    writeArray(new int[]{f2e.length}, output);
+    for (Set<Integer> f2eI: f2e){
+      int[] f2ePrimitive = (int[]) org.apache.commons.lang3.ArrayUtils.toPrimitive(f2eI);
+      writeArray(f2ePrimitive, output);
+    }
     writeArray(srcSuffixArray, output);
     writeArray(tgtSuffixArray, output);
     output.writeInt(numSentences, true);
@@ -102,17 +108,21 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
   public void read(Kryo kryo, Input input) {
     srcBitext = readArray(input);
     tgtBitext = readArray(input);
-    Integer[] readArrayResult = org.apache.commons.lang3.ArrayUtils.toObject(readArray(input));
-    e2f = new TreeSet[readArrayResult.length];
-    for(int i =0; i<readArrayResult.length; i++){
+    int e2fLength = readArray(input)[0];
+    e2f = new TreeSet[e2fLength];
+    for(int i = 0; i < e2fLength; i++){
       e2f[i] = new TreeSet();
-      e2f[i].add(readArrayResult[i]);
+      for (int alignmentLink: readArray(input)){
+        e2f[i].add(alignmentLink);
+      }
     }
-    readArrayResult = org.apache.commons.lang3.ArrayUtils.toObject(readArray(input));
-    f2e = new TreeSet[readArrayResult.length];
-    for(int i =0; i<readArrayResult.length; i++){
+    int f2eLength = readArray(input)[0];
+    f2e = new TreeSet[f2eLength];
+    for(int i = 0; i < f2eLength; i++){
       f2e[i] = new TreeSet();
-      f2e[i].add(readArrayResult[i]);
+      for (int alignmentLink: readArray(input)){
+        f2e[i].add(alignmentLink);
+      }
     }
     srcSuffixArray = readArray(input);
     tgtSuffixArray = readArray(input);

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -266,13 +266,9 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
     int tgtOffset = 0;
     for (AlignedSentence sentence : corpus) {
       System.arraycopy(sentence.source, 0, srcBitext, srcOffset, sentence.sourceLength());
-//      System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
+      System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
       System.arraycopy(sentence.target, 0, tgtBitext, tgtOffset, sentence.targetLength());
-//      System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
-      srcOffset += sentence.sourceLength();
-      tgtOffset += sentence.targetLength();
-      f2e = sentence.f2e;
-      e2f = sentence.e2f;
+      System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
       // Source points to target
       srcBitext[srcOffset] = toSentenceOffset(tgtOffset);
       // Target points to source

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -751,9 +751,7 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       SentencePair sp = new SentencePair(srcSuffixArray[i]);
       if(!exactMatch || sp.sourceLength() == sourceQuery.length) samples.add(sp);
     }
-    SuffixArraySample sample = new SuffixArraySample(samples, lb, ub);
-    System.out.println(sample.toString());
-    return sample;
+    return new SuffixArraySample(samples, lb, ub);
   }
   
   /**

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -222,15 +222,17 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
           logger.info("Discarding parallel example {}", fReader.getLineNumber());
         } else {
           System.arraycopy(sentence.source, 0, srcBitext, srcOffset, sentence.sourceLength());
-          System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
+//          System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
           System.arraycopy(sentence.target, 0, tgtBitext, tgtOffset, sentence.targetLength());
-          System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
+//          System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
           srcOffset += sentence.sourceLength();
           tgtOffset += sentence.targetLength();
           // Source points to target
           srcBitext[srcOffset] = toSentenceOffset(tgtOffset);
           // Target points to source
           tgtBitext[tgtOffset] = toSentenceOffset(srcOffset);
+          f2e = sentence.f2e;
+          e2f = sentence.e2f;
           ++srcOffset;
           ++tgtOffset;
         }        
@@ -751,7 +753,9 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       SentencePair sp = new SentencePair(srcSuffixArray[i]);
       if(!exactMatch || sp.sourceLength() == sourceQuery.length) samples.add(sp);
     }
-    return new SuffixArraySample(samples, lb, ub);
+    SuffixArraySample sample = new SuffixArraySample(samples, lb, ub);
+    System.out.println(sample.toString());
+    return sample;
   }
   
   /**

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -269,6 +269,8 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
       System.arraycopy(sentence.target, 0, tgtBitext, tgtOffset, sentence.targetLength());
       System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
+      srcOffset += sentence.sourceLength();
+      tgtOffset += sentence.targetLength();
       // Source points to target
       srcBitext[srcOffset] = toSentenceOffset(tgtOffset);
       // Target points to source

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArrayEntry.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArrayEntry.java
@@ -1,5 +1,7 @@
 package edu.stanford.nlp.mt.util;
 
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.IntStream;
 
 import edu.stanford.nlp.mt.train.GIZAWordAlignment;
@@ -14,7 +16,7 @@ import edu.stanford.nlp.mt.util.ParallelSuffixArray.SentencePair;
 public class ParallelSuffixArrayEntry {
   public final String[] source;
   public final String[] target;
-  public final int[][] f2e;
+  public final Set<Integer>[] f2e;
   // If the query was a target, then this is the left edge in the target array.
   // Otherwise, it is the left edge in the source array.
   public final int queryLeftEdge;
@@ -29,7 +31,7 @@ public class ParallelSuffixArrayEntry {
     this.queryLeftEdge = s.wordPosition;
     source = IntStream.range(0, s.sourceLength()).mapToObj(i -> v.get(s.source(i))).toArray(String[]::new);
     target = IntStream.range(0, s.targetLength()).mapToObj(i -> v.get(s.target(i))).toArray(String[]::new);
-    f2e = new int[source.length][];
+    f2e = new TreeSet[source.length];
     for (int i = 0; i < source.length; ++i) {
       f2e[i] = s.f2e(i);
     }

--- a/src/edu/stanford/nlp/mt/util/PhraseAlignment.java
+++ b/src/edu/stanford/nlp/mt/util/PhraseAlignment.java
@@ -1,8 +1,6 @@
 package edu.stanford.nlp.mt.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import edu.stanford.nlp.math.ArrayMath;
@@ -32,7 +30,7 @@ public class PhraseAlignment {
   private static final Map<String, PhraseAlignment> map = new ConcurrentHashMap<>(1000);
   
   private String str;
-  private final int[][] t2s;
+  private final Set<Integer>[] t2s;
 
   private PhraseAlignment(String s) {
     // System.err.println("align: "+s);
@@ -41,16 +39,16 @@ public class PhraseAlignment {
       t2s = null;
     } else {
       String[] els = s.split("\\s+");
-      t2s = new int[els.length][];
+      t2s = new TreeSet[els.length];
       for (int i = 0; i < t2s.length; ++i) {
         // System.err.printf("(%d): %s\n",i,els[i]);
         if (!els[i].equals("()")) {
           String[] els2 = els[i].split(",");
-          t2s[i] = new int[els2.length];
-          for (int j = 0; j < t2s[i].length; ++j) {
+          t2s[i] = new TreeSet<>();
+          for (int j = 0; j < t2s[i].size(); ++j) {
             // System.err.printf("(%d): %s\n",j,els2[j]);
             String num = els2[j].replaceAll("[()]", "");
-            t2s[i][j] = Integer.parseInt(num);
+            t2s[i].add(Integer.parseInt(num));
           }
         }
       }
@@ -58,7 +56,7 @@ public class PhraseAlignment {
     str = s.intern();
   }
 
-  public PhraseAlignment(int[][] e2f) {
+  public PhraseAlignment(Set<Integer>[] e2f) {
     this.t2s = e2f;
   }
 
@@ -78,11 +76,11 @@ public class PhraseAlignment {
     return str.hashCode();
   }
 
-  public int[] t2s(int i) {
-    return (t2s != null) ? (i < t2s.length ? t2s[i] : null) : new int[] { i };
+  public Set<Integer> t2s(int i) {
+    return (t2s != null) ? (i < t2s.length ? t2s[i] : null) : new TreeSet(Arrays.asList(new int[] { i }));
   }
 
-  private static String toStr(int[][] alignmentGrid) {
+  private static String toStr(Set<Integer>[] alignmentGrid) {
     StringBuilder sb = new StringBuilder();
     for (int ei=0; ei<alignmentGrid.length; ++ei) {
       if (ei>0) sb.append(' ');
@@ -142,6 +140,11 @@ public class PhraseAlignment {
     return (t2s != null) ? t2s.length : 0;
   }
 
+  public int alignmentMean(Set<Integer> alignment) {
+    int sum = alignment.stream().reduce(0, Integer::sum);
+    return sum/alignment.size();
+  }
+
   /**
    * Find average of source positions that correspond to the current tgtPos 
    * w.r.t to the given phrase alignment.
@@ -162,7 +165,7 @@ public class PhraseAlignment {
     int distance = 0;
     
     // System.err.println("findSrcAvgPos tgtPos=" + tgtPos + ", alignment=" + alignment);
-    int[] alignments;
+    Set<Integer> alignments;
     while(true){
       // look right
       int rightPos = tgtPos + distance;
@@ -171,7 +174,8 @@ public class PhraseAlignment {
         alignments = (rightPos < t2s.length ? t2s[rightPos] : null); // t2s(rightPos);
         if (alignments != null) {
           // System.err.print("right " + rightPos + ": " + Util.intArrayToString(alignments));
-          srcAvgPos = (int) ArrayMath.mean(alignments);
+
+          srcAvgPos = alignmentMean(alignments);
           break;
         }
         
@@ -184,7 +188,7 @@ public class PhraseAlignment {
         alignments = (leftPos < t2s.length ? t2s[leftPos] : null); // t2s(leftPos);
         if (alignments != null) {
           // System.err.print("left " + leftPos + ": " + Util.intArrayToString(alignments));
-          srcAvgPos = (int) ArrayMath.mean(alignments);
+          srcAvgPos = alignmentMean(alignments);
           break;
         }
         

--- a/src/edu/stanford/nlp/mt/util/PhraseAlignment.java
+++ b/src/edu/stanford/nlp/mt/util/PhraseAlignment.java
@@ -45,7 +45,7 @@ public class PhraseAlignment {
         if (!els[i].equals("()")) {
           String[] els2 = els[i].split(",");
           t2s[i] = new TreeSet<>();
-          for (int j = 0; j < t2s[i].size(); ++j) {
+          for (int j = 0; j < els2.length; ++j) {
             // System.err.printf("(%d): %s\n",j,els2[j]);
             String num = els2[j].replaceAll("[()]", "");
             t2s[i].add(Integer.parseInt(num));
@@ -141,6 +141,9 @@ public class PhraseAlignment {
   }
 
   public int alignmentMean(Set<Integer> alignment) {
+    if (alignment.size() == 0){
+      return 0;
+    }
     int sum = alignment.stream().reduce(0, Integer::sum);
     return sum/alignment.size();
   }

--- a/src/edu/stanford/nlp/mt/util/RichTranslation.java
+++ b/src/edu/stanford/nlp/mt/util/RichTranslation.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.text.DecimalFormat;
+import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Pattern;
 
@@ -240,7 +241,7 @@ public class RichTranslation<TK, FV> extends ScoredFeaturizedTranslation<TK, FV>
         throw new RuntimeException("Alignments are not enabled. Cannot extract alignments from translation.");
       }
       for (int i = 0; i < tgtLength; ++i) {
-        int[] sIndices = al.t2s(i);
+        Set<Integer> sIndices = al.t2s(i);
         if (sIndices != null) {
           final int tgtIndex = tgtPosition + i;
           for (int srcOffset : sIndices) {

--- a/test/edu/stanford/nlp/mt/util/AlignedSentenceTest.java
+++ b/test/edu/stanford/nlp/mt/util/AlignedSentenceTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import edu.stanford.nlp.mt.util.ParallelCorpus.Alignment;
 
+import java.util.Set;
+
 /**
  * Unit test.
  * 
@@ -17,6 +19,13 @@ public class AlignedSentenceTest {
   private static final int[] source = new int[]{0, 1, 2, 3};
   private static final int[] target = new int[]{4, 5, 6, 7, 8, 9, 10, 11};
   private static final String alignment = "0-1,2 1-0 2-7,3,4,5,6";
+
+  private Integer[] getIntegerArray(Set<Integer> alignment){
+    if (alignment == null){
+      return new Integer[0];
+    }
+    return alignment.toArray(new Integer[alignment.size()]);
+  }
   
   @Test
   public void testAlignment() {
@@ -24,36 +33,38 @@ public class AlignedSentenceTest {
     AlignedSentence sentence = new AlignedSentence(source, target, al.f2e, al.e2f);
     
     // Source tests
-    int[] f0Links = sentence.f2e(0);
+    Integer[] f0Links = getIntegerArray(sentence.f2e(0));
     assertEquals(2, f0Links.length);
-    assertEquals(1, f0Links[0]);
-    assertEquals(2, f0Links[1]);
+
+    assertEquals(1, (int) f0Links[0]);
+    assertEquals(2, (int) f0Links[1]);
     
-    int[] f1Links = sentence.f2e(1);
+    Integer[] f1Links = getIntegerArray(sentence.f2e(1));
     assertEquals(1, f1Links.length);
-    assertEquals(0, f1Links[0]);
+    assertEquals(0, (int) f1Links[0]);
     
-    int[] f2Links = sentence.f2e(2);
-    assertEquals(4, f2Links.length);
-    assertEquals(3, f2Links[0]);
-    assertEquals(4, f2Links[1]);
-    assertEquals(5, f2Links[2]);
-    assertEquals(6, f2Links[3]);
+    Integer[] f2Links = getIntegerArray(sentence.f2e(2));
+    assertEquals(5, f2Links.length);
+    assertEquals(3, (int) f2Links[0]);
+    assertEquals(4, (int) f2Links[1]);
+    assertEquals(5, (int) f2Links[2]);
+    assertEquals(6, (int) f2Links[3]);
+    assertEquals(7, (int) f2Links[4]);
     
-    int[] f3Links = sentence.f2e(3);
+    Integer[] f3Links = getIntegerArray(sentence.f2e(3));
     assertEquals(0, f3Links.length);
     
     // Target tests
-    int[] e0Links = sentence.e2f(0);
+    Integer[] e0Links = getIntegerArray(sentence.e2f(0));
     assertEquals(1, e0Links.length);
-    assertEquals(1, e0Links[0]);
+    assertEquals(1, (int) e0Links[0]);
     
-    int[] e1Links = sentence.e2f(1);
+    Integer[] e1Links = getIntegerArray(sentence.e2f(1));
     assertEquals(1, e1Links.length);
-    assertEquals(0, e1Links[0]);
+    assertEquals(0, (int) e1Links[0]);
     
-    int[] e2Links = sentence.e2f(2);
+    Integer[] e2Links = getIntegerArray(sentence.e2f(2));
     assertEquals(1, e2Links.length);
-    assertEquals(0, e2Links[0]);
+    assertEquals(0, (int) e2Links[0]);
   }
 }


### PR DESCRIPTION
In the current implementation of AlignedSentence, the alignment arrays are flattened to integers, where every link is represented in an 8 bit sequence. This flattening scheme allows for only 4 alignment links to be persisted. This causes all target terms to be truncated to 4 tokens.

To overcome this, the alignments will be represented using the original `Set<Integer>[]` representation, where `TreeSet` is used to store the alignment links, maintaining the correct ordering. 