### PR TITLE
Initialize empty treesets

### DIFF
--- a/src/edu/stanford/nlp/mt/util/ParallelCorpus.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelCorpus.java
@@ -125,7 +125,7 @@ public class ParallelCorpus implements Iterable<AlignedSentence>, Serializable {
       }
       if (f2e[srcPos] == null) f2e[srcPos] = new TreeSet<>();
       Arrays.stream(point.substring(splitIdx+1, point.length()).split(","))
-      .mapToInt(tgtStr -> Integer.parseInt(tgtStr)).sorted().forEach(tgtPos -> {
+      .mapToInt(Integer::parseInt).sorted().forEach(tgtPos -> {
         if (tgtPos < 0 || tgtPos >= targetLen) {
           logger.error("Target length: {}  target index: {} alignmentStr: {}", targetLen, tgtPos, alignStr);
           throw new ArrayIndexOutOfBoundsException();

--- a/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
+++ b/src/edu/stanford/nlp/mt/util/ParallelSuffixArray.java
@@ -228,17 +228,17 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
           logger.info("Discarding parallel example {}", fReader.getLineNumber());
         } else {
           System.arraycopy(sentence.source, 0, srcBitext, srcOffset, sentence.sourceLength());
-//          System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
+          System.arraycopy(sentence.f2e, 0, f2e, srcOffset, sentence.f2e.length);
           System.arraycopy(sentence.target, 0, tgtBitext, tgtOffset, sentence.targetLength());
-//          System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
+          System.arraycopy(sentence.e2f, 0, e2f, tgtOffset, sentence.e2f.length);
           srcOffset += sentence.sourceLength();
           tgtOffset += sentence.targetLength();
           // Source points to target
           srcBitext[srcOffset] = toSentenceOffset(tgtOffset);
+          f2e[srcOffset] = new TreeSet<>();
           // Target points to source
           tgtBitext[tgtOffset] = toSentenceOffset(srcOffset);
-          f2e = sentence.f2e;
-          e2f = sentence.e2f;
+          e2f[tgtOffset] = new TreeSet<>();
           ++srcOffset;
           ++tgtOffset;
         }        
@@ -257,7 +257,6 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
    * @param corpus
    */
   private void loadCorpus(ParallelCorpus corpus) {
-    logger.info("Flattening parallel corpus");
     TimeKeeper timer = TimingUtils.start();
     numSentences = corpus.size();
     int numSourcePositions = corpus.numSourcePositions();
@@ -279,8 +278,10 @@ public class ParallelSuffixArray implements Serializable,KryoSerializable {
       tgtOffset += sentence.targetLength();
       // Source points to target
       srcBitext[srcOffset] = toSentenceOffset(tgtOffset);
+      f2e[srcOffset] = new TreeSet<>();
       // Target points to source
       tgtBitext[tgtOffset] = toSentenceOffset(srcOffset);
+      e2f[tgtOffset] = new TreeSet<>();
       ++srcOffset;
       ++tgtOffset;
     }


### PR DESCRIPTION
For the positions being marked with source and target sentence delimiters, the e2f and f2e alignments were `Null`, causing `NullPointerExceptions` while serialization of the tb model. 

THe corresponding positions will be initialized with empty TreeSet objects now