### PR TITLE
Update log4j to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,8 +146,8 @@ dependencies {
   compile group: 'com.esotericsoftware', name: 'kryo', version: '5.1.1'
   compile group: 'it.unimi.dsi', name: 'fastutil', version: '8.5.4'
   compile group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
-  compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
-  compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
   compile group: 'com.lmax', name: 'disruptor', version: '3.4.4'
   


### PR DESCRIPTION
Fix CVE-2021-45046