### PR TITLE
Release/3.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 // Release version
-version = '3.7.1-SNAPSHOT'
+version = '3.7.1'
 
 repositories {
     maven {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 // Release version
-version = '3.7.1'
+version = '3.7.2-SNAPSHOT'
 
 repositories {
     maven {


### PR DESCRIPTION
Produces version 3.7.1, which includes the log4j upgrades. This has been pushed to nexus. Reopens main as version 3.7.2-SNAPSHOT.

(Do not squash these two commits!)